### PR TITLE
Do not prepend composer autoloader

### DIFF
--- a/addons/composer.json
+++ b/addons/composer.json
@@ -1,5 +1,8 @@
 {
     "require": {
         "php-di/php-di": "5.0"
+    },
+    "config":{
+        "prepend-autoloader": false
     }
 }


### PR DESCRIPTION
fixes https://github.com/CybotAS/CookiebotWP/issues/141 

This worked for us (https://github.com/matomo-org/matomo/blob/3.12.0/composer.json#L25)

Afterwards you will probably need to update composer before building the release next time