### PR TITLE
Changed initialazation of cookiebot plugin to be after theme load to allow themes to hook in to addons as well

### DIFF
--- a/addons/cookiebot-addons-init.php
+++ b/addons/cookiebot-addons-init.php
@@ -113,7 +113,7 @@ class Cookiebot_Addons {
 		 *
 		 * @since 1.1.0
 		 */
-		add_action( 'plugins_loaded', array(
+		add_action( 'after_setup_theme', array(
 			new Plugin_Controller( $this->container->get( 'Settings_Service_Interface' ) ),
 			'load_active_addons',
 		) );

--- a/cookiebot.php
+++ b/cookiebot.php
@@ -54,7 +54,7 @@ final class Cookiebot_WP {
 	 * @access  public
 	 */
 	function __construct() {
-		add_action('plugins_loaded', array($this, 'cookiebot_init'), 5);
+		add_action('after_setup_theme', array($this, 'cookiebot_init'), 5);
 		register_activation_hook( __FILE__ , array($this, 'activation'));
 		register_deactivation_hook( __FILE__, 'cookiebot_addons_plugin_deactivated' );
 


### PR DESCRIPTION
As far as I can see, there is no problem in changing the initialization hook to be after_setup_theme.

I can not see any hooks in your initialization function running before after_setup_theme.

By changing the hook, themes can also hook in to the addons array.