### PR TITLE
Feature/addon enhanced ecommerce for woocommerce store

### DIFF
--- a/addons/controller/addons/enhanced-ecommerce-for-woocommerce-store/enhanced-ecommerce-for-woocommerce-store.php
+++ b/addons/controller/addons/enhanced-ecommerce-for-woocommerce-store/enhanced-ecommerce-for-woocommerce-store.php
@@ -70,16 +70,14 @@
 		 * @since 1.3.0
 		 */
 		public function cookiebot_addon_enhanced_ecommerce_for_woocommerce_store() {
-			cookiebot_addons_remove_class_action('woocommerce_after_checkout_billing_form', 'Enhanced_Ecommerce_Google_Analytics_Public', 'checkout_step_3_tracking', 10);
-			cookiebot_addons_remove_class_action('woocommerce_after_add_to_cart_button', 'Enhanced_Ecommerce_Google_Analytics_Public', 'add_to_cart', 10);
-			cookiebot_addons_remove_class_action('wp_head', 'Enhanced_Ecommerce_Google_Analytics_Public', 'add_dev_id', 10);
-			cookiebot_addons_remove_class_action('wp_footer', 'Enhanced_Ecommerce_Google_Analytics_Public', 'tvc_store_meta_data', 10);
-			cookiebot_addons_remove_class_action('woocommerce_thankyou', 'Enhanced_Ecommerce_Google_Analytics_Public', 'ecommerce_tracking_code', 10);
-			cookiebot_addons_remove_class_action('wp_head', 'Enhanced_Ecommerce_Google_Analytics_Public', 'ee_settings', 10);
-			cookiebot_addons_remove_class_action('wp_footer', 'Enhanced_Ecommerce_Google_Analytics_Public', 't_products_impre_clicks', 10);
-			cookiebot_addons_remove_class_action('woocommerce_after_shop_loop_item', 'Enhanced_Ecommerce_Google_Analytics_Public', 'bind_product_metadata', 10);
-			cookiebot_addons_remove_class_action('woocommerce_after_single_product', 'Enhanced_Ecommerce_Google_Analytics_Public', 'product_detail_view', 10);
-			cookiebot_addons_remove_class_action('woocommerce_after_cart', 'Enhanced_Ecommerce_Google_Analytics_Public', 'remove_cart_tracking', 10);
+			$this->buffer_output->add_tag( 'wp_footer', 25, array(
+				'gtag' => $this->get_cookie_types()
+			), false );
+
+			$this->buffer_output->add_tag( 'wp_head', 10, array(
+				'gtag' => $this->get_cookie_types(),
+				'gaProperty' => $this->get_cookie_types(),
+			), false );
 		}
 
 		/**


### PR DESCRIPTION
Hi

I have changed this implementation back to what I have done in the first place and added an extra check.

I don't understand why you changed the way it was implementet with this commit: https://github.com/CybotAS/CookiebotWP/commit/86d6e03d11b20db31338315e1f21a69a8dd879e6 ?

As far as I can see, you remove every action even though the user has acceptet statistics cookies? Or am I missing something?
Which means that tracking will never take place?

And if I'm missing something, and it is the correct way to do it, it will fail in some cases (with DIBS EASY ex.)
Because you need to add these too:

```
cookiebot_addons_remove_class_action('woocommerce_before_checkout_billing_form', 'Enhanced_Ecommerce_Google_Analytics_Public', 'checkout_step_1_tracking', 10);
cookiebot_addons_remove_class_action('woocommerce_after_checkout_billing_form', 'Enhanced_Ecommerce_Google_Analytics_Public', 'checkout_step_2_tracking', 10);
```

I think the correct is to go back to my implementation, or you have to check the cookie consent state before removing actions, but then it will not work before a page change.