### PR TITLE
Feature/output buffer caching

### DIFF
--- a/addons/lib/buffer/buffer-output-tag.php
+++ b/addons/lib/buffer/buffer-output-tag.php
@@ -65,6 +65,8 @@ class Buffer_Output_Tag implements Buffer_Output_Tag_Interface {
 		$this->priority = $priority;
 		$this->keywords = $keywords;
 		$this->use_cache = $use_cache;
+
+		$this->transient_name = "cookiebot_output_buffer_{$tag}_{$priority}";
 	}
 
 	/**

--- a/addons/lib/buffer/buffer-output-tag.php
+++ b/addons/lib/buffer/buffer-output-tag.php
@@ -64,9 +64,10 @@ class Buffer_Output_Tag implements Buffer_Output_Tag_Interface {
 		$this->tag      = $tag;
 		$this->priority = $priority;
 		$this->keywords = $keywords;
-		$this->use_cache = $use_cache;
 
 		$this->transient_name = "cookiebot_output_buffer_{$tag}_{$priority}";
+
+		$this->set_use_cache($use_cache);
 	}
 
 	/**
@@ -78,6 +79,15 @@ class Buffer_Output_Tag implements Buffer_Output_Tag_Interface {
 	 */
 	public function merge_keywords( $keywords ) {
 		$this->keywords = array_merge( $this->keywords, $keywords );
+	}
+
+	/**
+	 * Set use cache
+	 *
+	 * @param $use_cache
+	 */
+	public function set_use_cache($use_cache) {
+		$this->use_cache = $use_cache;
 	}
 
 	/**

--- a/addons/lib/buffer/buffer-output.php
+++ b/addons/lib/buffer/buffer-output.php
@@ -31,6 +31,10 @@ class Buffer_Output implements Buffer_Output_Interface {
 		 */
 		if ( isset( $this->tags[ $unique_id ] ) ) {
 			$this->tags[ $unique_id ]->merge_keywords( $keywords );
+			
+			if(!$use_cache) {
+				$this->tags[ $unique_id ]->set_use_cache(false);
+			}
 		}
 		else {
 			$this->tags[ $unique_id ] = $tag;


### PR DESCRIPTION
Output buffer caching was not working as intended. If output buffer was used for more than one hook, the other hooks would use caching from first hook. Resulting in some scripts was removed while others was implementet more than once.

Solved by setting $transient_name in Buffer_Output_Tag