### PR TITLE
Fix PHP Notice: WP_Block_Type_Registry::register was called incorrectly

### DIFF
--- a/cookiebot.php
+++ b/cookiebot.php
@@ -210,7 +210,7 @@ final class Cookiebot_WP {
 		
 		
 		//Add Gutenberg block
-		add_action( 'enqueue_block_assets', array($this,'gutenberg_block_setup') );
+		add_action( 'init', array($this,'gutenberg_block_setup') );
 		add_action( 'enqueue_block_editor_assets', array($this,'gutenberg_block_admin_assets') );   
 	}
 	


### PR DESCRIPTION
This pull request fixes an PHP Notice on pages using Gutenberg. (closes #193)