### PR TITLE
added XDEBUGMODE=coverage to support travis builds with XDEBUG 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ php:
   - '7.3'
 
 env:
-  - WP_PROJECT_TYPE=plugin WP_VERSION=latest WP_MULTISITE=0 WP_TEST_URL=http://localhost:12000 WP_TEST_USER=test WP_TEST_USER_PASS=test
+  - WP_PROJECT_TYPE=plugin WP_VERSION=latest WP_MULTISITE=0 WP_TEST_URL=http://localhost:12000 WP_TEST_USER=test WP_TEST_USER_PASS=test XDEBUG_MODE=coverage
 
 before_script:
   # Install composer packages before trying to activate themes or plugins


### PR DESCRIPTION
This pull request should fix travis builds with XDEBUG version 3

issue: https://travis-ci.community/t/xdebug-3-is-installed-by-default-breaking-builds/10748