### PR TITLE
#220: sets "Tested up to" to 5.7.2 in readme.txt

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 * Contributors: cookiebot,phpgeekdk,aytac
 * Tags: cookie, compliance, eu, gdpr, europe, cookie consent, consent, ccpa
 * Requires at least: 4.4
-* Tested up to: 5.4.2
+* Tested up to: 5.7.2
 * Stable tag: 3.10.0
 * Requires PHP: 5.6
 * License: GPLv2 or later


### PR DESCRIPTION
Since travis always adds `WP_VERSION=latest` to the env string, I set the "tested up to" version in readme.txt to 5.7.2.
This should fix the warnings on the plugin's wordpress.org page.