### PR TITLE
243: Updated tests + added support for blocking the new script handle…

### DIFF
--- a/addons/controller/addons/add-to-any/add-to-any.php
+++ b/addons/controller/addons/add-to-any/add-to-any.php
@@ -90,7 +90,12 @@ class Add_To_Any implements Cookiebot_Addons_Interface {
 
 		// External js, so manipulate attributes
 		if ( has_action( 'wp_enqueue_scripts', 'A2A_SHARE_SAVE_enqueue_script' ) ) {
+			// add-to-any plugin version < 1.8.2
 			$this->script_loader_tag->add_tag( 'addtoany', $this->get_cookie_types() );
+
+			// add-to-any-plugin version >= 1.8.2
+			$this->script_loader_tag->add_tag( 'addtoany-core', $this->get_cookie_types() );
+			$this->script_loader_tag->add_tag( 'addtoany-jquery', $this->get_cookie_types() );
 		}
 
 		add_filter( 'the_content', array(

--- a/addons/tests/integration/addons/test-add-to-any.php
+++ b/addons/tests/integration/addons/test-add-to-any.php
@@ -16,6 +16,9 @@ class Test_Add_To_Any extends Addons_Base {
 		$content = $this->curl_get_content( $url );
 
 		// test the content
-		$this->assertNotFalse( strpos( $content, "wp_enqueue_script( 'addtoany'" ) );
+		$this->assertNotFalse( strpos( $content, "add_action( 'wp_enqueue_scripts', 'A2A_SHARE_SAVE_stylesheet'" ) );
+		$this->assertNotFalse( strpos( $content, "\$script_handle = 'addtoany-core';" ) );
+		$this->assertNotFalse( strpos( $content, "wp_enqueue_script( \$script_handle );" ) );
+		$this->assertNotFalse( strpos( $content, "wp_enqueue_script( 'addtoany-jquery'" ) );
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -197,6 +197,10 @@ You are able to define the mapping between Cookiebot and the WP Consent API in t
 
 ## Changelog ##
 
+### fix/243-travis-build-is-failing-for-test-add-to-any ###
+* Updated tests for add-to-any plugin version >= 1.8.2
+* Added support for blocking the new script handles for add-to-any plugin version >= 1.8.2
+
 ### 3.11.2 - 2021-11-17 ###
 * Updated CookieBot logo on settings page + network settings page
 


### PR DESCRIPTION
…s for add-to-any plugin version >= 1.8.2

### Tests
- added check if function name still exists since this is also checked in the addon logic
- since the tests are only applicable to the plugin trunk code, I removed the check for the old script handle `addtoany`
- added checks for the new script handles `addtoany-core` and `addtoany-jquery`

### Addon Logic
- added script_loader_tag tags for the new `addtoany-core` and `addtoany-jquery` script handles, alongside the old `addtoany` script handle