### PR TITLE
Feat/247 cmp widget

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,18 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "d983f55d5d44ac468214f15c76be4b73",
+    "packages": [],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "plugin-api-version": "2.1.0"
+}

--- a/src/settings/Menu_Settings.php
+++ b/src/settings/Menu_Settings.php
@@ -50,6 +50,7 @@ class Menu_Settings {
 		register_setting( 'cookiebot', 'cookiebot-cbid' );
 		register_setting( 'cookiebot', 'cookiebot-language' );
 		register_setting( 'cookiebot', 'cookiebot-nooutput' );
+		register_setting( 'cookiebot', 'cookiebot-widget' );
 		register_setting( 'cookiebot', 'cookiebot-nooutput-admin' );
 		register_setting( 'cookiebot', 'cookiebot-output-logged-in' );
 		register_setting( 'cookiebot', 'cookiebot-autoupdate' );

--- a/src/settings/Network_Menu_Settings.php
+++ b/src/settings/Network_Menu_Settings.php
@@ -70,6 +70,7 @@ class Network_Menu_Settings {
 		update_site_option( 'cookiebot-script-tag-cd-attribute', $_POST['cookiebot-script-tag-cd-attribute'] );
 		update_site_option( 'cookiebot-autoupdate', $_POST['cookiebot-autoupdate'] );
 		update_site_option( 'cookiebot-nooutput', $_POST['cookiebot-nooutput'] );
+		update_site_option( 'cookiebot-widget', $_POST['cookiebot-widget'] );
 		update_site_option( 'cookiebot-nooutput-admin', $_POST['cookiebot-nooutput-admin'] );
 		update_site_option( 'cookiebot-cookie-blocking-mode', $_POST['cookiebot-cookie-blocking-mode'] );
 

--- a/src/settings/pages/Debug_Page.php
+++ b/src/settings/pages/Debug_Page.php
@@ -78,6 +78,7 @@ class Debug_Page implements Settings_Page_Interface {
 		$debug_output .= 'Add async/defer to banner tag: ' . ( get_option( 'cookiebot-script-tag-uc-attribute' ) !== '' ? get_option( 'cookiebot-script-tag-uc-attribute' ) : 'None' ) . "\n";
 		$debug_output .= 'Add async/defer to declaration tag: ' . ( get_option( 'cookiebot-script-tag-cd-attribute' ) !== '' ? get_option( 'cookiebot-script-tag-cd-attribute' ) : 'None' ) . "\n";
 		$debug_output .= 'Auto update: ' . ( get_option( 'cookiebot-autoupdate' ) === '1' ? 'Enabled' : 'Not enabled' ) . "\n";
+		$debug_output .= 'CMP Widget: ' . ( get_option( 'cookiebot-widget' ) === '1' ? 'Yes' : 'No' ) . "\n";
 		$debug_output .= 'Hide Cookie Popup: ' . ( get_option( 'cookiebot-nooutput' ) === '1' ? 'Yes' : 'No' ) . "\n";
 		$debug_output .= 'Disable Cookiebot in WP Admin: ' . ( get_option( 'cookiebot-nooutput-admin' ) === '1' ? 'Yes' : 'No' ) . "\n";
 		$debug_output .= 'Enable Cookiebot on front end while logged in: ' . ( get_option( 'cookiebot-output-logged-in' ) === '1' ? 'Yes' : 'No' ) . "\n";

--- a/src/view/admin/settings/network-settings-page.php
+++ b/src/view/admin/settings/network-settings-page.php
@@ -227,6 +227,27 @@
 				</td>
 			</tr>
 			<tr id="cookiebot-setting-hide-popup">
+				<th scope="row"><?php esc_html_e( 'Show CMP Widget', 'cookiebot' ); ?></th>
+				<td>
+					<input type="checkbox" name="cookiebot-widget" value="1"
+						<?php
+						checked(
+							1,
+							get_site_option( 'cookiebot-widget' )
+						);
+						?>
+					/>
+					<p class="description">
+						<?php
+						esc_html_e(
+							'Allow the cookiebot CMP widget for your website.',
+							'cookiebot'
+						);
+						?>
+					</p>
+				</td>
+			</tr>
+			<tr id="cookiebot-setting-hide-popup">
 				<th scope="row"><?php esc_html_e( 'Hide Cookie Popup', 'cookiebot' ); ?></th>
 				<td>
 					<input type="checkbox" name="cookiebot-nooutput" value="1"

--- a/src/view/admin/settings/settings-page.php
+++ b/src/view/admin/settings/settings-page.php
@@ -312,6 +312,46 @@
 				}
 				?>
 				<tr id="cookiebot-setting-hide-popup">
+					<th scope="row"><?php esc_html_e( 'Show CMP Widget', 'cookiebot' ); ?></th>
+					<td>
+						<?php
+						$disabled = false;
+						if ( $is_ms && get_site_option( 'cookiebot-widget' ) ) {
+							$disabled = true;
+							echo '<input type="checkbox" checked disabled />';
+						} else {
+							?>
+							<input type="checkbox" name="cookiebot-widget" value="1"
+								<?php
+								checked(
+									1,
+									get_option( 'cookiebot-widget', false )
+								);
+								?>
+							/>
+							<?php
+						}
+						?>
+						<p class="description">
+							<?php
+							if ( $disabled ) {
+								echo '<b>' . esc_html__(
+									'Network setting applied. Please contact website administrator to change this setting.',
+									'cookiebot'
+								) . '</b><br />';
+							}
+							?>
+
+							<?php
+							esc_html_e(
+								'Allow the cookiebot CMP widget for your website.',
+								'cookiebot'
+							);
+							?>
+						</p>
+					</td>
+				</tr>
+				<tr id="cookiebot-setting-hide-popup">
 					<th scope="row"><?php esc_html_e( 'Hide Cookie Popup', 'cookiebot' ); ?></th>
 					<td>
 						<?php

--- a/src/view/frontend/scripts/cookiebot-js.php
+++ b/src/view/frontend/scripts/cookiebot-js.php
@@ -8,6 +8,9 @@
 		id="Cookiebot"
 		src="https://consent.cookiebot.com/uc.js"
 		data-cbid="<?php echo esc_attr( $cbid ); ?>"
+	<?php if ( (bool) get_option( 'cookiebot-widget' ) !== false ) : ?>
+		data-widget-enabled="true"
+	<?php endif; ?>
 	<?php if ( (bool) get_option( 'cookiebot-iab' ) !== false ) : ?>
 		data-framework="IAB"
 	<?php endif; ?>


### PR DESCRIPTION
#247 Added option to allow the widget + assigned extra attribute to cookiebot script.

Frontend with the widget button on the bottom left
<img width="524" alt="Screenshot 2022-01-14 at 17 00 53" src="https://user-images.githubusercontent.com/485174/149546400-a8d71b8b-f249-47d1-80a5-c1f0a0d333d0.png">

Backend settings page
<img width="1355" alt="Screenshot 2022-01-14 at 17 00 35" src="https://user-images.githubusercontent.com/485174/149546408-06e16b1f-e126-476d-bd58-366dcd584aa8.png">
t