### PR TITLE
Revert "Removed unused capture groups from RegExp"

### DIFF
--- a/src/addons/controller/addons/jetpack/widget/Google_Maps_Jetpack_Widget.php
+++ b/src/addons/controller/addons/jetpack/widget/Google_Maps_Jetpack_Widget.php
@@ -87,7 +87,7 @@ class Google_Maps_Jetpack_Widget extends Base_Jetpack_Widget {
 			/**
 			 * Pattern to get all iframes
 			 */
-			$pattern = '/<iframe.*?>.*?<\/iframe>/i';
+			$pattern = '/<iframe(.*?)?>(.|\s)*?<\/iframe>/i';
 
 			/**
 			 * Get all scripts and add cookieconsent if it does match with the criterion


### PR DESCRIPTION
This reverts commit 64bb753205cdbf093daaee31737f04bf6acc3a94.

Modification of the RegExp might cause unexpected errors. This issue will be marked in SonarCloud as passed manually.