### PR TITLE
Replace fixed URL with call to admin_url()

### DIFF
--- a/src/view/admin/settings/dashboard-page.php
+++ b/src/view/admin/settings/dashboard-page.php
@@ -32,7 +32,7 @@ $header->display();
 							<h2 class="cb-main__card__title">
 								<?php echo esc_html__( 'I already have a Cookiebot CMP account', 'cookiebot' ); ?>
 							</h2>
-							<a href="/wp-admin/admin.php?page=<?php echo esc_html( Settings_Page::ADMIN_SLUG ); ?>"
+							<a href="<?php esc_url( admin_url( 'admin.php?page=' . Settings_Page::ADMIN_SLUG ) ); ?>"
 							   class="cb-btn cb-main-btn">
 								<?php echo esc_html__( 'Connect my existing account', 'cookiebot' ); ?>
 							</a>

--- a/src/view/admin/settings/dashboard-page.php
+++ b/src/view/admin/settings/dashboard-page.php
@@ -32,7 +32,7 @@ $header->display();
 							<h2 class="cb-main__card__title">
 								<?php echo esc_html__( 'I already have a Cookiebot CMP account', 'cookiebot' ); ?>
 							</h2>
-							<a href="<?php esc_url( admin_url( 'admin.php?page=' . Settings_Page::ADMIN_SLUG ) ); ?>"
+							<a href="<?php echo esc_url( admin_url( 'admin.php?page=' . Settings_Page::ADMIN_SLUG ) ); ?>"
 							   class="cb-btn cb-main-btn">
 								<?php echo esc_html__( 'Connect my existing account', 'cookiebot' ); ?>
 							</a>

--- a/src/view/admin/settings/dashboard-page.php
+++ b/src/view/admin/settings/dashboard-page.php
@@ -32,7 +32,7 @@ $header->display();
 							<h2 class="cb-main__card__title">
 								<?php echo esc_html__( 'I already have a Cookiebot CMP account', 'cookiebot' ); ?>
 							</h2>
-							<a href="<?php echo esc_url( admin_url( 'admin.php?page=' . Settings_Page::ADMIN_SLUG ) ); ?>"
+							<a href="<?php echo esc_url( add_query_arg( 'page', Settings_Page::ADMIN_SLUG, admin_url( 'admin.php' ) ) ); ?>"
 							   class="cb-btn cb-main-btn">
 								<?php echo esc_html__( 'Connect my existing account', 'cookiebot' ); ?>
 							</a>


### PR DESCRIPTION
Fixes #284 by using [admin_url](https://developer.wordpress.org/reference/functions/admin_url/) function.

Also uses correct escaping function: [esc_html](https://developer.wordpress.org/reference/functions/esc_html/) is for HTML content only! There are dedicated escaping functions for [URLs](https://developer.wordpress.org/reference/functions/esc_url/) and tag [attributes](https://developer.wordpress.org/reference/functions/esc_attr/).