### PR TITLE
Fixed an issue with consent ignoring replacing the script tag inside script

### DIFF
--- a/src/lib/script_loader_tag/Script_Loader_Tag.php
+++ b/src/lib/script_loader_tag/Script_Loader_Tag.php
@@ -110,7 +110,7 @@ class Script_Loader_Tag implements Script_Loader_Tag_Interface {
 
 		// Exclude any scripts not related to currently processed script handle. Only script itself and inline block
 		// before/after are supported.
-		if ( ! preg_match( "/(?:^|\s)id=['\"]$quoted_handle-js(?:-(?:after|before))?['\"]/", $tag_attributes ) ) {
+		if ( ! preg_match( "/(?:^|\s)id=['\"]$quoted_handle(?:-js-(?:after|before))?['\"]/", $tag_attributes ) ) {
 			return false;
 		}
 

--- a/src/lib/script_loader_tag/Script_Loader_Tag.php
+++ b/src/lib/script_loader_tag/Script_Loader_Tag.php
@@ -67,8 +67,21 @@ class Script_Loader_Tag implements Script_Loader_Tag_Interface {
 		apply_filters( 'cybot_cookiebot_ignore_scripts', $this->ignore_scripts );
 
 		if ( $this->check_ignore_script( $src ) ) {
-            //phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
-			return str_replace( '<script ', '<script data-cookieconsent="ignore" ', $tag );
+			return preg_replace_callback(
+				'/<script\s*(?<atts>[^>]*)>/',
+				function ( $tag ) use ( $handle ) {
+					// Prevent modification of the script tags inside the other script tag by validating the ID of the
+					// script and checking if we already set the consent status for the script. This will fix the issue
+					// on Gutenberg editor pages.
+					if ( ! self::validate_attributes_for_consent_ignore( $handle, $tag['atts'] ) ) {
+						return $tag[0];
+					}
+
+                    //phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+					return str_replace( '<script ', '<script data-cookieconsent="ignore" ', $tag[0] );
+				},
+				$tag
+			);
 		}
 
 		return $tag;
@@ -82,5 +95,26 @@ class Script_Loader_Tag implements Script_Loader_Tag_Interface {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Check if the script tag attributes are valid for the injection of the consent ignore attribute.
+	 *
+	 * @param string $script_handle Handle of the enqueued script. Required for identification of the scripts.
+	 * @param string $tag_attributes List of the attributes for the tag.
+	 *
+	 * @return bool True if the attributes are valid for the injection of the consent ignore attribute.
+	 */
+	private static function validate_attributes_for_consent_ignore( string $script_handle, string $tag_attributes ) {
+		$quoted_handle = preg_quote( $script_handle, '/' );
+
+		// Exclude any scripts not related to currently processed script handle. Only script itself and inline block
+		// before/after are supported.
+		if ( ! preg_match( "/(?:^|\s)id=['\"]$quoted_handle-js(?:-(?:after|before))?['\"]/", $tag_attributes ) ) {
+			return false;
+		}
+
+		// Exclude any scripts already containing the consent ignore attribute.
+		return is_bool( strpos( $tag_attributes, 'data-cookieconsent=' ) );
 	}
 }

--- a/src/lib/script_loader_tag/Script_Loader_Tag.php
+++ b/src/lib/script_loader_tag/Script_Loader_Tag.php
@@ -105,7 +105,7 @@ class Script_Loader_Tag implements Script_Loader_Tag_Interface {
 	 *
 	 * @return bool True if the attributes are valid for the injection of the consent ignore attribute.
 	 */
-	private static function validate_attributes_for_consent_ignore( string $script_handle, string $tag_attributes ) {
+	private static function validate_attributes_for_consent_ignore( $script_handle, $tag_attributes ) {
 		$quoted_handle = preg_quote( $script_handle, '/' );
 
 		// Exclude any scripts not related to currently processed script handle. Only script itself and inline block


### PR DESCRIPTION
With WordPress 6.2, Gutenberg began inserting scripts into the JavaScript logic. Because of this change, our logic with ignoring consent on selected scripts was working incorrectly, breaking the JavaScript and causing editor to throw the error.

Example of invalid replacement:

```html
<!-- Original code before replacement -->
<script id="script-handle-js">
  // This is just an arbitrary example of the code:
  //           The script tag inside the JavaScript code
  //            |
  //            V
  console.log("<script src='https:\/\/example.wpengine.com\/wp-includes\/js\/dist\/vendor\/wp-polyfill-inert.min.js?ver=3.1.2' id='wp-polyfill-inert-js'><\/script>")
</script>

<!-- Code after replacement -->
<script data-cookieconsent="ignore" id="script-handle-js">
  //    ^
  //    |
  //   This tag was correctly updated with data-cookieconsent attribute.
  //
  //           But this tag was modified as well.
  //            |
  //            V
  console.log("<script data-cookieconsent="ignore" src='https:\/\/example.wpengine.com\/wp-includes\/js\/dist\/vendor\/wp-polyfill-inert.min.js?ver=3.1.2' id='wp-polyfill-inert-js'><\/script>")
  //                                       ^
  //                                       |
  //                                      Attribute is breaking the string, causing an error.
</script>
```

This PR will bring additional validation to the logic:

- Check for ID of the script tag;
- Check for already existing `data-cookieconsent` attribute.

Example of result code after this change:

```html
<!-- Code after replacement with this PR in place -->
<script data-cookieconsent="ignore" id="script-handle-js">
  //    ^                               ^
  //    |                               |
  //   This tag was updated since the ID of script matches the script handle.
  console.log("<script src='https:\/\/example.wpengine.com\/wp-includes\/js\/dist\/vendor\/wp-polyfill-inert.min.js?ver=3.1.2' id='wp-polyfill-inert-js'><\/script>")
  //                   ^
  //                   |
  //                   Script tag and attributes are intact.
</script>
```