### PR TITLE
Updating the Travis CI configuration with PHP 8-8.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os: linux
-dist: jammy
+dist: bionic
 
 services:
   - mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,10 @@ matrix:
     - php: 8.2
       env: PHPUNIT_VERSION=9.6.7
       dist: jammy
+      addons: # PHP 8.2 fails to start because of missing library
+        apt:
+          packages:
+            - "libonig5"
     - php: 8.1
       env: PHPUNIT_VERSION=9.6.7
     - php: 8.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ matrix:
       env: PHPUNIT_VERSION=6.5.14
     - php: 5.6
       env: PHPUNIT_VERSION=5.7.27
+      dist: xenial
 
 before_install:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,10 @@ matrix:
   include:
     - php: 7.4
       env: PHPCS=1
+    # Version 8.2 is not available for selected version of Ubuntu
     - php: 8.2
       env: PHPUNIT_VERSION=10.1.2
+      dist: jammy
     - php: 8.1
       env: PHPUNIT_VERSION=10.1.2
     - php: 8.0
@@ -29,8 +31,10 @@ matrix:
       env: PHPUNIT_VERSION=7.5.20
     - php: 7.1
       env: PHPUNIT_VERSION=7.5.20
+    # Versions lower than 7.0 are not available for the newer versions of the Ubuntu
     - php: 7.0
       env: PHPUNIT_VERSION=6.5.14
+      dist: xenial
     - php: 5.6
       env: PHPUNIT_VERSION=5.7.27
       dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,12 @@ matrix:
   include:
     - php: 7.4
       env: PHPCS=1
+    - php: 8.2
+      env: PHPUNIT_VERSION=10.1.2
+    - php: 8.1
+      env: PHPUNIT_VERSION=10.1.2
+    - php: 8.0
+      env: PHPUNIT_VERSION=9.6.7
     - php: 7.4
       env: PHPUNIT_VERSION=7.5.20
     - php: 7.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os: linux
-dist: xenial
+dist: jammy
 
 services:
   - mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,10 @@ matrix:
       env: PHPCS=1
     # Version 8.2 is not available for selected version of Ubuntu
     - php: 8.2
-      env: PHPUNIT_VERSION=10.1.2
+      env: PHPUNIT_VERSION=9.6.7
       dist: jammy
     - php: 8.1
-      env: PHPUNIT_VERSION=10.1.2
+      env: PHPUNIT_VERSION=9.6.7
     - php: 8.0
       env: PHPUNIT_VERSION=9.6.7
     - php: 7.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,14 +15,13 @@ matrix:
   include:
     - php: 7.4
       env: PHPCS=1
-    # Version 8.2 is not available for selected version of Ubuntu
     - php: 8.2
       env: PHPUNIT_VERSION=9.6.7
-      dist: jammy
-      addons: # PHP 8.2 fails to start because of missing library
+      dist: jammy # Version 8.2 is not available in the "bionic", newer version is required.
+      addons:
         apt:
           packages:
-            - "libonig5"
+            - "libonig5" # This library is required, since Travis fails to properly install & run the PHP 8.2
     - php: 8.1
       env: PHPUNIT_VERSION=9.6.7
     - php: 8.0
@@ -35,10 +34,9 @@ matrix:
       env: PHPUNIT_VERSION=7.5.20
     - php: 7.1
       env: PHPUNIT_VERSION=7.5.20
-    # Versions lower than 7.0 are not available for the newer versions of the Ubuntu
     - php: 7.0
       env: PHPUNIT_VERSION=6.5.14
-      dist: xenial
+      dist: xenial # Versions 7.0 and lower not available in "bionic", older version ("xenial") required to run
     - php: 5.6
       env: PHPUNIT_VERSION=5.7.27
       dist: xenial

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -13,11 +13,6 @@ require_once __DIR__ . '/./helpers.php';
 require_once __DIR__ . '/../src/addons/addons.php';
 require_once __DIR__ . '/../src/lib/helper.php';
 
-if ( PHP_MAJOR_VERSION >= 8 ) {
-	echo 'The scaffolded tests cannot currently be run on PHP 8.0+. See https://github.com/wp-cli/scaffold-command/issues/285' . PHP_EOL; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-	exit( 1 );
-}
-
 $cybot_cookiebot_tests_dir = getenv( 'WP_TESTS_DIR' );
 
 if ( ! $cybot_cookiebot_tests_dir ) {

--- a/tests/integration/addons/Test_Addthis.php
+++ b/tests/integration/addons/Test_Addthis.php
@@ -9,9 +9,6 @@ use WP_UnitTestCase;
 
 class Test_Addthis extends WP_UnitTestCase {
 
-	public function setUp() {
-	}
-
 	/**
 	 * @covers \cybot\cookiebot\addons\controller\addons\addthis\Addthis
 	 * @throws ExpectationFailedException

--- a/tests/integration/addons/Test_Custom_Facebook_Feed.php
+++ b/tests/integration/addons/Test_Custom_Facebook_Feed.php
@@ -9,9 +9,6 @@ use WP_UnitTestCase;
 
 class Test_Custom_Facebook_Feed extends WP_UnitTestCase {
 
-	public function setUp() {
-	}
-
 	/**
 	 * @covers \cybot\cookiebot\addons\controller\addons\custom_facebook_feed\Custom_Facebook_Feed
 	 * @throws ExpectationFailedException

--- a/tests/integration/addons/Test_Custom_Facebook_Feed_Version_2_17_1.php
+++ b/tests/integration/addons/Test_Custom_Facebook_Feed_Version_2_17_1.php
@@ -9,9 +9,6 @@ use WP_UnitTestCase;
 
 class Test_Custom_Facebook_Feed_Version_2_17_1 extends WP_UnitTestCase {
 
-	public function setUp() {
-	}
-
 	/**
 	 * @covers \cybot\cookiebot\addons\controller\addons\custom_facebook_feed\Custom_Facebook_Feed_Version_2_17_1
 	 * @throws ExpectationFailedException

--- a/tests/integration/addons/Test_Facebook_For_Woocommerce.php
+++ b/tests/integration/addons/Test_Facebook_For_Woocommerce.php
@@ -9,9 +9,6 @@ use WP_UnitTestCase;
 
 class Test_Facebook_For_Woocommerce extends WP_UnitTestCase {
 
-	public function setUp() {
-	}
-
 	/**
 	 * @covers \cybot\cookiebot\addons\controller\addons\facebook_for_woocommerce\Facebook_For_Woocommerce
 	 * @throws ExpectationFailedException

--- a/tests/integration/addons/Test_Ga_Google_Analytics.php
+++ b/tests/integration/addons/Test_Ga_Google_Analytics.php
@@ -9,9 +9,6 @@ use WP_UnitTestCase;
 
 class Test_Ga_Google_Analytics extends WP_UnitTestCase {
 
-	public function setUp() {
-	}
-
 	/**
 	 * @covers \cybot\cookiebot\addons\controller\addons\ga_google_analytics\Ga_Google_Analytics
 	 * @throws ExpectationFailedException

--- a/tests/integration/addons/Test_Gadwp.php
+++ b/tests/integration/addons/Test_Gadwp.php
@@ -9,9 +9,6 @@ use WP_UnitTestCase;
 
 class Test_Gadwp extends WP_UnitTestCase {
 
-	public function setUp() {
-	}
-
 	/**
 	 * @covers \cybot\cookiebot\addons\controller\addons\gadwp\Gadwp
 	 * @throws ExpectationFailedException

--- a/tests/integration/addons/Test_Google_Analyticator.php
+++ b/tests/integration/addons/Test_Google_Analyticator.php
@@ -9,9 +9,6 @@ use WP_UnitTestCase;
 
 class Test_Google_Analyticator extends WP_UnitTestCase {
 
-	public function setUp() {
-	}
-
 	/**
 	 * @covers \cybot\cookiebot\addons\controller\addons\google_analyticator\Google_Analyticator
 	 * @throws ExpectationFailedException

--- a/tests/integration/addons/Test_Google_Analytics.php
+++ b/tests/integration/addons/Test_Google_Analytics.php
@@ -9,9 +9,6 @@ use WP_UnitTestCase;
 
 class Test_Google_Analytics extends WP_UnitTestCase {
 
-	public function setUp() {
-	}
-
 	/**
 	 * @covers \cybot\cookiebot\addons\controller\addons\google_analytics\Google_Analytics
 	 * @throws ExpectationFailedException

--- a/tests/integration/addons/Test_Google_Site_Kit.php
+++ b/tests/integration/addons/Test_Google_Site_Kit.php
@@ -9,9 +9,6 @@ use WP_UnitTestCase;
 
 class Test_Google_Site_Kit extends WP_UnitTestCase {
 
-	public function setUp() {
-	}
-
 	/**
 	 * @covers \cybot\cookiebot\addons\controller\addons\google_site_kit\Google_Site_Kit
 	 * @throws ExpectationFailedException

--- a/tests/integration/addons/Test_Hubspot_Leadin.php
+++ b/tests/integration/addons/Test_Hubspot_Leadin.php
@@ -9,9 +9,6 @@ use WP_UnitTestCase;
 
 class Test_Hubspot_Leadin extends WP_UnitTestCase {
 
-	public function setUp() {
-	}
-
 	/**
 	 * @covers \cybot\cookiebot\addons\controller\addons\hubspot_leadin\Hubspot_Leadin
 	 * @throws ExpectationFailedException

--- a/tests/integration/addons/Test_Hubspot_Tracking_Code.php
+++ b/tests/integration/addons/Test_Hubspot_Tracking_Code.php
@@ -9,9 +9,6 @@ use WP_UnitTestCase;
 
 class Test_Hubspot_Tracking_Code extends WP_UnitTestCase {
 
-	public function setUp() {
-	}
-
 	/**
 	 * @covers \cybot\cookiebot\addons\controller\addons\hubspot_tracking_code\Hubspot_Tracking_Code
 	 * @throws ExpectationFailedException

--- a/tests/integration/addons/Test_Instagram_Feed.php
+++ b/tests/integration/addons/Test_Instagram_Feed.php
@@ -9,9 +9,6 @@ use WP_UnitTestCase;
 
 class Test_Instagram_Feed extends WP_UnitTestCase {
 
-	public function setUp() {
-	}
-
 	/**
 	 * @covers \cybot\cookiebot\addons\controller\addons\instagram_feed\Instagram_Feed
 	 * @throws ExpectationFailedException

--- a/tests/integration/addons/Test_Jetpack_Widgets.php
+++ b/tests/integration/addons/Test_Jetpack_Widgets.php
@@ -9,9 +9,6 @@ use WP_UnitTestCase;
 
 class Test_Jetpack_Widgets extends WP_UnitTestCase {
 
-	public function setUp() {
-	}
-
 	/**
 	 * @covers \cybot\cookiebot\addons\controller\addons\jetpack\widget\Facebook_Jetpack_Widget
 	 * @throws ExpectationFailedException

--- a/tests/integration/addons/Test_Lightspeed_Cache.php
+++ b/tests/integration/addons/Test_Lightspeed_Cache.php
@@ -9,9 +9,6 @@ use WP_UnitTestCase;
 
 class Test_Lightspeed_Cache extends WP_UnitTestCase {
 
-	public function setUp() {
-	}
-
 	/**
 	 * @covers \cybot\cookiebot\addons\controller\addons\litespeed_cache\Litespeed_Cache
 	 * @throws ExpectationFailedException

--- a/tests/integration/addons/Test_Ninja_Forms.php
+++ b/tests/integration/addons/Test_Ninja_Forms.php
@@ -9,9 +9,6 @@ use WP_UnitTestCase;
 
 class Test_Ninja_Forms extends WP_UnitTestCase {
 
-	public function setUp() {
-	}
-
 	/**
 	 * @covers \cybot\cookiebot\addons\controller\addons\ninja_forms\Ninja_Forms
 	 * @throws ExpectationFailedException

--- a/tests/integration/addons/Test_Official_Facebook_Pixel.php
+++ b/tests/integration/addons/Test_Official_Facebook_Pixel.php
@@ -9,9 +9,6 @@ use WP_UnitTestCase;
 
 class Test_Official_Facebook_Pixel extends WP_UnitTestCase {
 
-	public function setUp() {
-	}
-
 	/**
 	 * @covers \cybot\cookiebot\addons\controller\addons\official_facebook_pixel\Official_Facebook_Pixel
 	 * @throws ExpectationFailedException

--- a/tests/integration/addons/Test_Optinmonster.php
+++ b/tests/integration/addons/Test_Optinmonster.php
@@ -9,9 +9,6 @@ use WP_UnitTestCase;
 
 class Test_Optinmonster extends WP_UnitTestCase {
 
-	public function setUp() {
-	}
-
 	/**
 	 * @covers \cybot\cookiebot\addons\controller\addons\optinmonster\Optinmonster
 	 * @throws ExpectationFailedException

--- a/tests/integration/addons/Test_Pixel_Caffeine.php
+++ b/tests/integration/addons/Test_Pixel_Caffeine.php
@@ -9,9 +9,6 @@ use WP_UnitTestCase;
 
 class Test_Pixel_Caffeine extends WP_UnitTestCase {
 
-	public function setUp() {
-	}
-
 	/**
 	 * @covers \cybot\cookiebot\addons\controller\addons\pixel_caffeine\Pixel_Caffeine
 	 * @throws ExpectationFailedException

--- a/tests/integration/addons/Test_Wd_Google_Analytics.php
+++ b/tests/integration/addons/Test_Wd_Google_Analytics.php
@@ -9,9 +9,6 @@ use WP_UnitTestCase;
 
 class Test_Wd_Google_Analytics extends WP_UnitTestCase {
 
-	public function setUp() {
-	}
-
 	/**
 	 * @covers \cybot\cookiebot\addons\controller\addons\wd_google_analytics\Wd_Google_Analytics
 	 * @throws ExpectationFailedException

--- a/tests/integration/addons/Test_Wp_Analytify.php
+++ b/tests/integration/addons/Test_Wp_Analytify.php
@@ -9,9 +9,6 @@ use WP_UnitTestCase;
 
 class Test_Wp_Analytify extends WP_UnitTestCase {
 
-	public function setUp() {
-	}
-
 	/**
 	 * @covers \cybot\cookiebot\addons\controller\addons\wp_analytify\Wp_Analytify
 	 * @throws ExpectationFailedException

--- a/tests/integration/addons/Test_Wp_Google_Analytics_Events.php
+++ b/tests/integration/addons/Test_Wp_Google_Analytics_Events.php
@@ -9,8 +9,6 @@ use WP_UnitTestCase;
 
 class Test_Wp_Google_Analytics_Events extends WP_UnitTestCase {
 
-	public function setUp() {}
-
 	/**
 	 * @covers \cybot\cookiebot\addons\controller\addons\wp_google_analytics_events\Wp_Google_Analytics_Events
 	 * @throws ExpectationFailedException

--- a/tests/integration/addons/Test_Wp_Mautic.php
+++ b/tests/integration/addons/Test_Wp_Mautic.php
@@ -9,9 +9,6 @@ use WP_UnitTestCase;
 
 class Test_Wp_Mautic extends WP_UnitTestCase {
 
-	public function setUp() {
-	}
-
 	/**
 	 * @covers \cybot\cookiebot\addons\controller\addons\wp_mautic\Wp_Mautic
 	 * @throws ExpectationFailedException

--- a/tests/integration/addons/Test_Wp_Piwik.php
+++ b/tests/integration/addons/Test_Wp_Piwik.php
@@ -9,9 +9,6 @@ use WP_UnitTestCase;
 
 class Test_Wp_Piwik extends WP_UnitTestCase {
 
-	public function setUp() {
-	}
-
 	/**
 	 * @covers \cybot\cookiebot\addons\controller\addons\wp_piwik\Wp_Piwik
 	 * @throws ExpectationFailedException

--- a/tests/unit/Test_Cookie_Consent.php
+++ b/tests/unit/Test_Cookie_Consent.php
@@ -10,9 +10,6 @@ use WP_UnitTestCase;
 class Test_Cookie_Consent extends WP_UnitTestCase {
 	const COOKIE = '{"stamp":"0boMmPgsG8gUTRvMkOLtyZ1uLvOFJobBbNb23IZO/TpY3eETvRxFfg==","necessary":"true","preferences":"true","statistics":"false","marketing":"false","ver":"1","utc":"1557479161596"}';
 
-	public function setUp() {
-	}
-
 	/**
 	 * Test Cookie Consent with valid encoded json format
 	 *


### PR DESCRIPTION
**Added three configuration for PHP 8, 8.1 and 8.2 with newer version of the PHPUnit**

For these newer versions of the PHP, PHPUnit 9 was selected. PHPUnit 10 fails to work, since one of the methods used by test suite was removed from this version.

**Updated the base version of OS used in tests**

Versions 7.1 up to 8.1 can be installed on the `bionic` version of the Ubuntu.
Versions 7.0 and lower are not distributed in the version of the Ubuntu anymore, so these version will keep using `xenial` version.
Versions 8.2 is not distributes in `bionic` version of Ubuntu, so `jammy` version used instead.

Additionally, PHP 8.2 fails to isntall & run without manual installation of the `libonig5`.

**Resolved issues with PHP 8+ tests**

In order for the tests to work all selected versions, empty `setUp` methods were deleted from all the tests. In the PHP 8+, polyfill for the tests uses return type for the `setUp` method causing all the tests for these versions to fail.

Additionally, in `tests/bootstrap.php` the line blocking tests on newer versions of PHP was removed, since issues related to these versions seems to be resolved.

https://github.com/wp-cli/scaffold-command/pull/297
https://github.com/wp-cli/scaffold-command/pull/297/commits/fea4ec830c6fb1a36971f242f34c626eb4a74a8d