### PR TITLE
Make Embed Autocorrect-addon also work with ACF

### DIFF
--- a/src/addons/controller/addons/embed_autocorrect/Embed_Autocorrect.php
+++ b/src/addons/controller/addons/embed_autocorrect/Embed_Autocorrect.php
@@ -50,6 +50,18 @@ class Embed_Autocorrect extends Base_Cookiebot_Other_Addon {
 			1000
 		); // Ensure it is executed as the last filter
 
+		// add filters to handle autocorrection in Advanced Custom Fields (ACF) WYSIWYG-content fields
+		if(! class_exists('ACF') )  {
+			add_filter(
+				'acf_the_content',
+				array(
+					$this,
+					'cookiebot_addon_embed_autocorrect_content',
+				),
+				1000
+			); // Ensure it is executed as the last filter
+		}
+		
 		// add filters to handle autocorrection in widget text
 		add_filter(
 			'widget_text',


### PR DESCRIPTION
The widely-used plugin Advanced Custom Fields (ACF) does not use the `the_content` filter, but has it own `acf_the_content`-filter.
This addition will also apply the placeholder-functionality to these fields 