### PR TITLE
4.3.7 update

### DIFF
--- a/cookiebot.php
+++ b/cookiebot.php
@@ -5,7 +5,7 @@ Plugin Name: Cookie banner plugin for WordPress – Cookiebot CMP by Usercentric
 Plugin URI: https://www.cookiebot.com/
 Description: The Cookiebot CMP WordPress cookie banner and cookie policy help you comply with the major data protection laws (GDPR, ePrivacy, CCPA, LGPD, etc.) in a simple and fully automated way. Secure your website and get peace of mind.
 Author: Usercentrics A/S
-Version: 4.3.6
+Version: 4.3.7
 Author URI: https://www.cookiebot.com/
 Text Domain: cookiebot
 Domain Path: /langs

--- a/readme.txt
+++ b/readme.txt
@@ -304,7 +304,7 @@ Cookiebot CMP version 4.3.7 is out! This release adds bugfixes and small feature
 
 ####What's new####
 * Set WordPress tested up to version to 6.4.3
-* Add ignore parameter to inline scripts associated to ignored scripts
+* Add ignore parameter to inline scripts associated to ignored scripts Props: @jaakkolehtonen
 
 ####Bugfixes####
 * Fix fatal error when no purposes added to restrictions

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 * Contributors: cookiebot,phpgeekdk,aytac
 * Tags: cookie banner, GDPR, CCPA, WordPress cookie banner, cookie policy, ePrivacy, dsgvo, privacy compliance, DMA, data privacy, cmp, cookies
 * Requires at least: 4.4
-* Tested up to: 6.4.1
+* Tested up to: 6.4.3
 * Stable tag: 4.3.6
 * Requires PHP: 5.6
 * License: GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@
 * Tags: cookie banner, GDPR, CCPA, WordPress cookie banner, cookie policy, ePrivacy, dsgvo, privacy compliance, DMA, data privacy, cmp, cookies
 * Requires at least: 4.4
 * Tested up to: 6.4.3
-* Stable tag: 4.3.6
+* Stable tag: 4.3.7
 * Requires PHP: 5.6
 * License: GPLv2 or later
 

--- a/readme.txt
+++ b/readme.txt
@@ -297,6 +297,18 @@ If your favorite plugin isn't supported, feel free to request it via our [GitHub
 ## Changelog ##
 **Cookiebot CMP Plugin will soon no longer support PHP 5. If your website still runs on this version we recommend upgrading so you can continue enjoying the features Cookiebot CMP offers.**
 
+### 4.3.7 ###
+Release date: March 6th 2024
+
+Cookiebot CMP version 4.3.7 is out! This release adds bugfixes and small features. Here is the complete list of this update
+
+####What's new####
+* Set WordPress tested up to version to 6.4.3
+* Add ignore parameter to inline scripts associated to ignored scripts
+
+####Bugfixes####
+* Fix fatal error when no purposes added to restrictions
+
 ### 4.3.6 ###
 Release date: February 28th 2024
 

--- a/src/lib/Cookiebot_Javascript_Helper.php
+++ b/src/lib/Cookiebot_Javascript_Helper.php
@@ -230,7 +230,8 @@ class Cookiebot_Javascript_Helper {
 		$attribute = array();
 
 		foreach ( $custom_tcf_restrictions as $vendor => $restrictions ) {
-			$attribute [] = '{"VendorId":' . $vendor . ',"DisallowPurposes":[' . implode( ', ', $restrictions['purposes'] ) . ']}';
+			$purposes     = ! empty( $restrictions['purposes'] ) ? $restrictions['purposes'] : array();
+			$attribute [] = '{"VendorId":' . $vendor . ',"DisallowPurposes":[' . implode( ', ', $purposes ) . ']}';
 		}
 
 		return implode( ',', $attribute );

--- a/src/lib/Cookiebot_WP.php
+++ b/src/lib/Cookiebot_WP.php
@@ -13,7 +13,7 @@ use DomainException;
 use RuntimeException;
 
 class Cookiebot_WP {
-	const COOKIEBOT_PLUGIN_VERSION  = '4.3.6';
+	const COOKIEBOT_PLUGIN_VERSION  = '4.3.7';
 	const COOKIEBOT_MIN_PHP_VERSION = '5.6.0';
 
 	/**

--- a/src/settings/pages/Iab_Page.php
+++ b/src/settings/pages/Iab_Page.php
@@ -38,9 +38,7 @@ class Iab_Page implements Settings_Page_Interface {
 			'custom_tcf_special_features' => self::get_vendor_custom_option( 'cookiebot-tcf-special-features' ),
 			'custom_tcf_vendors'          => self::get_vendor_custom_option( 'cookiebot-tcf-vendors' ),
 			'custom_tcf_ac_vendors'       => self::get_vendor_custom_option( 'cookiebot-tcf-ac-vendors' ),
-			'custom_tcf_restrictions'     => ! empty( get_option( 'cookiebot-tcf-disallowed' ) ) ?
-				get_option( 'cookiebot-tcf-disallowed' ) :
-				array( '0' => array( 'purposes' => array() ) ),
+			'custom_tcf_restrictions'     => self::get_restrictions_custom_option(),
 			'vendor_data'                 => self::get_vendor_list_data(),
 			'extra_providers'             => self::get_extra_providers(),
 		);
@@ -70,6 +68,27 @@ class Iab_Page implements Settings_Page_Interface {
 
 	private function get_vendor_custom_option( $option ) {
 		return empty( get_option( $option ) ) ? array() : get_option( $option );
+	}
+
+	private function get_restrictions_custom_option() {
+		$restrictions            = array();
+		$custom_tcf_restrictions = get_option( 'cookiebot-tcf-disallowed' );
+
+		if ( ! empty( $custom_tcf_restrictions ) ) {
+			foreach ( $custom_tcf_restrictions as $vendor => $t ) {
+				if ( empty( $t['purposes'] ) ) {
+					$restrictions[ $vendor ]['purposes'] = array();
+				}
+			}
+		} else {
+			$restrictions = array(
+				'0' => array(
+					'purposes' => array(),
+				),
+			);
+		}
+
+		return $restrictions;
 	}
 
 	private function get_vendor_array( $items, $item_name ) {


### PR DESCRIPTION
- Set WordPress tested up to version to 6.4.3
- Add ignore parameter to inline scripts associated to ignored scripts
- Fix fatal error when no purposes added to restrictions