### PR TITLE
Fix security check on survey submission

### DIFF
--- a/cookiebot.php
+++ b/cookiebot.php
@@ -5,7 +5,7 @@ Plugin Name: Cookie banner plugin for WordPress – Cookiebot CMP by Usercentric
 Plugin URI: https://www.cookiebot.com/
 Description: The Cookiebot CMP WordPress cookie banner and cookie policy help you comply with the major data protection laws (GDPR, ePrivacy, CCPA, LGPD, etc.) in a simple and fully automated way. Secure your website and get peace of mind.
 Author: Usercentrics A/S
-Version: 4.4.1
+Version: 4.4.2
 Author URI: https://www.cookiebot.com/
 Text Domain: cookiebot
 Domain Path: /langs

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@
 * Tags: WordPress cookie banner, GDPR, privacy compliance, cookie policy, cmp
 * Requires at least: 4.4
 * Tested up to: 6.7.1
-* Stable tag: 4.4.1
+* Stable tag: 4.4.2
 * Requires PHP: 5.6
 * License: GPLv2 or later
 
@@ -284,6 +284,14 @@ If your favorite plugin isn't supported, feel free to request it via our [GitHub
 
 ## Changelog ##
 **Cookiebot CMP Plugin will soon no longer support PHP 5. If your website still runs on this version we recommend upgrading so you can continue enjoying the features Cookiebot CMP offers.**
+
+### 4.4.2 ###
+Release date: March 6th 2025
+
+Cookiebot CMP version 4.4.2 is out! This release adds a bugfix.
+
+####Bugfixes####
+* Fix security issue - improve authorization check on survey submission Props: [Peter Thaleikis](https://peterthaleikis.com/)
 
 ### 4.4.1 ###
 Release date: January 30th 2025

--- a/readme.txt
+++ b/readme.txt
@@ -286,7 +286,7 @@ If your favorite plugin isn't supported, feel free to request it via our [GitHub
 **Cookiebot CMP Plugin will soon no longer support PHP 5. If your website still runs on this version we recommend upgrading so you can continue enjoying the features Cookiebot CMP offers.**
 
 ### 4.4.2 ###
-Release date: March 6th 2025
+Release date: March 5th 2025
 
 Cookiebot CMP version 4.4.2 is out! This release adds a bugfix.
 

--- a/src/lib/Cookiebot_Review.php
+++ b/src/lib/Cookiebot_Review.php
@@ -3,6 +3,7 @@
 namespace cybot\cookiebot\lib;
 
 use WP_REST_SERVER;
+use function current_user_can;
 use cybot\cookiebot\settings\pages\Debug_Page;
 
 class Cookiebot_Review {
@@ -132,7 +133,7 @@ class Cookiebot_Review {
 	 */
 	public function send_uninstall_survey() {
 		global $wpdb;
-		if ( ! check_ajax_referer( 'cookiebot_survey_nonce', 'survey_nonce', false ) ) {
+		if ( ! check_ajax_referer( 'cookiebot_survey_nonce', 'survey_nonce', false ) || ! current_user_can('administrator') ) {
 			wp_send_json_error( esc_html__( 'Sorry you are not allowed to do this.', 'cookiebot' ), 401 );
 		}
 		if ( ! isset( $_POST['reason_id'] ) ) {

--- a/src/lib/Cookiebot_Review.php
+++ b/src/lib/Cookiebot_Review.php
@@ -133,7 +133,7 @@ class Cookiebot_Review {
 	 */
 	public function send_uninstall_survey() {
 		global $wpdb;
-		if ( ! check_ajax_referer( 'cookiebot_survey_nonce', 'survey_nonce', false ) || ! current_user_can('administrator') ) {
+		if ( ! check_ajax_referer( 'cookiebot_survey_nonce', 'survey_nonce', false ) || ! current_user_can( 'deactivate_plugins' ) ) {
 			wp_send_json_error( esc_html__( 'Sorry you are not allowed to do this.', 'cookiebot' ), 401 );
 		}
 		if ( ! isset( $_POST['reason_id'] ) ) {

--- a/src/lib/Cookiebot_WP.php
+++ b/src/lib/Cookiebot_WP.php
@@ -14,7 +14,7 @@ use RuntimeException;
 
 class Cookiebot_WP {
 
-	const COOKIEBOT_PLUGIN_VERSION  = '4.4.1';
+	const COOKIEBOT_PLUGIN_VERSION  = '4.4.2';
 	const COOKIEBOT_MIN_PHP_VERSION = '5.6.0';
 
 	/**

--- a/tests/integration/addons/Test_Official_Facebook_Pixel.php
+++ b/tests/integration/addons/Test_Official_Facebook_Pixel.php
@@ -16,7 +16,7 @@ class Test_Official_Facebook_Pixel extends WP_UnitTestCase {
 	 * @throws \Exception
 	 */
 	public function test_official_facebook_pixel_pageview() {
-		$content = Official_Facebook_Pixel::get_svn_file_content( 'core/FacebookPixel.php' );
+		$content = Official_Facebook_Pixel::get_svn_file_content( 'core/class-facebookpixel.php' );
 		$snippet = <<<TEXT
 <!-- Meta Pixel Code -->
 <script type='text/javascript'>
@@ -39,12 +39,14 @@ TEXT;
 	 * @throws \Exception
 	 */
 	public function test_official_facebook_pixel_caldera_form() {
-		$content = Official_Facebook_Pixel::get_svn_file_content( 'integration/FacebookWordpressCalderaForm.php' );
+		$content = Official_Facebook_Pixel::get_svn_file_content( 'integration/class-facebookwordpresscalderaform.php' );
 		$snippet = <<<TEXT
 add_action(
-      'caldera_forms_ajax_return',
-      array(__CLASS__, 'injectLeadEvent'),
-      10, 2);
+            'caldera_forms_ajax_return',
+            array( __CLASS__, 'injectLeadEvent' ),
+            10,
+            2
+        );
 TEXT;
 
 		$this->assertNotFalse( strpos( $content, $snippet ) );
@@ -57,19 +59,23 @@ TEXT;
 	 * @throws \Exception
 	 */
 	public function test_official_facebook_pixel_contact_form_7() {
-		$content    = Official_Facebook_Pixel::get_svn_file_content( 'integration/FacebookWordpressContactForm7.php' );
+		$content    = Official_Facebook_Pixel::get_svn_file_content( 'integration/class-facebookwordpresscontactform7.php' );
 		$snippets[] = <<<TEXT
 add_action(
-      'wpcf7_submit',
-      array(__CLASS__, 'trackServerEvent'),
-      10, 2);
+            'wpcf7_submit',
+            array( __CLASS__, 'trackServerEvent' ),
+            10,
+            2
+        );
 TEXT;
 
 		$snippets[] = <<<TEXT
 add_action(
-      'wpcf7_feedback_response',
-      array(__CLASS__, 'injectLeadEvent'),
-      20, 2);
+            'wpcf7_feedback_response',
+            array( __CLASS__, 'injectLeadEvent' ),
+            20,
+            2
+        );
 TEXT;
 
 		foreach ( $snippets as $snippet ) {
@@ -84,22 +90,22 @@ TEXT;
 	 * @throws \Exception
 	 */
 	public function test_official_facebook_pixel_formidable_form() {
-		$content    = Official_Facebook_Pixel::get_svn_file_content( 'integration/FacebookWordpressFormidableForm.php' );
+		$content    = Official_Facebook_Pixel::get_svn_file_content( 'integration/class-facebookwordpressformidableform.php' );
 		$snippets[] = <<<TEXT
 add_action(
-      'frm_after_create_entry',
-      array(__CLASS__, 'trackServerEvent'),
-      20,
-      2
-    );
+            'frm_after_create_entry',
+            array( __CLASS__, 'trackServerEvent' ),
+            20,
+            2
+        );
 TEXT;
 
 		$snippets[] = <<<TEXT
 add_action(
-      'wp_footer',
-       array(__CLASS__, 'injectLeadEvent'),
-       20
-    );
+            'wp_footer',
+            array( __CLASS__, 'injectLeadEvent' ),
+            20
+        );
 TEXT;
 
 		foreach ( $snippets as $snippet ) {
@@ -114,34 +120,40 @@ TEXT;
 	 * @throws \Exception
 	 */
 	public function test_official_facebook_pixel_easy_digital_downloads() {
-		$content    = Official_Facebook_Pixel::get_svn_file_content( 'integration/FacebookWordpressEasyDigitalDownloads.php' );
+		$content    = Official_Facebook_Pixel::get_svn_file_content( 'integration/class-facebookwordpresseasydigitaldownloads.php' );
 		$snippets[] = <<<TEXT
 add_action(
-      'edd_payment_receipt_after',
-      array(__CLASS__, 'trackPurchaseEvent'),
-      10, 2);
+            'edd_payment_receipt_after',
+            array( __CLASS__, 'trackPurchaseEvent' ),
+            10,
+            2
+        );
 TEXT;
 
 		$snippets[] = <<<TEXT
 add_action(
-      'edd_after_download_content',
-      array(__CLASS__, 'injectAddToCartListener')
-    );
+            'edd_after_download_content',
+            array( __CLASS__, 'injectAddToCartListener' )
+        );
 TEXT;
 
 		$snippets[] = <<<TEXT
-self::addPixelFireForHook(array(
-      'hook_name' => 'edd_after_checkout_cart',
-      'classname' => __CLASS__,
-      'inject_function' => 'injectInitiateCheckoutEvent'));
+self::add_pixel_fire_for_hook(
+            array(
+                'hook_name'       => 'edd_after_checkout_cart',
+                'classname'       => __CLASS__,
+                'inject_function' => 'injectInitiateCheckoutEvent',
+            )
+        );
 TEXT;
 
 		$snippets[] = <<<TEXT
 add_action(
-      'edd_after_download_content',
-      array(__CLASS__, 'injectViewContentEvent'),
-      40, 1
-    );
+            'edd_after_download_content',
+            array( __CLASS__, 'injectViewContentEvent' ),
+            40,
+            1
+        );
 TEXT;
 
 		foreach ( $snippets as $snippet ) {
@@ -156,13 +168,15 @@ TEXT;
 	 * @throws \Exception
 	 */
 	public function test_official_facebook_pixel_mailchimp_for_wp() {
-		$content = Official_Facebook_Pixel::get_svn_file_content( 'integration/FacebookWordpressMailchimpForWp.php' );
+		$content = Official_Facebook_Pixel::get_svn_file_content( 'integration/class-facebookwordpressmailchimpforwp.php' );
 		$snippet = <<<TEXT
-self::addPixelFireForHook(array(
-      'hook_name' => 'mc4wp_form_subscribed',
-      'classname' => __CLASS__,
-      'inject_function' => 'injectLeadEvent'));
-  }
+self::add_pixel_fire_for_hook(
+        array(
+            'hook_name'       => 'mc4wp_form_subscribed',
+            'classname'       => __CLASS__,
+            'inject_function' => 'injectLeadEvent',
+        )
+    );
 TEXT;
 
 		$this->assertNotFalse( strpos( $content, $snippet ) );
@@ -175,12 +189,14 @@ TEXT;
 	 * @throws \Exception
 	 */
 	public function test_official_facebook_pixel_ninja_forms() {
-		$content = Official_Facebook_Pixel::get_svn_file_content( 'integration/FacebookWordpressNinjaForms.php' );
+		$content = Official_Facebook_Pixel::get_svn_file_content( 'integration/class-facebookwordpressninjaforms.php' );
 		$snippet = <<<TEXT
 add_action(
-      'ninja_forms_submission_actions',
-      array(__CLASS__, 'injectLeadEvent'),
-      10, 3);
+            'ninja_forms_submission_actions',
+            array( __CLASS__, 'injectLeadEvent' ),
+            10,
+            3
+        );
 TEXT;
 
 		$this->assertNotFalse( strpos( $content, $snippet ) );
@@ -193,29 +209,38 @@ TEXT;
 	 * @throws \Exception
 	 */
 	public function test_official_facebook_pixel_woocommerce() {
-		$content    = Official_Facebook_Pixel::get_svn_file_content( 'integration/FacebookWordpressWooCommerce.php' );
+		$content    = Official_Facebook_Pixel::get_svn_file_content( 'integration/class-facebookwordpresswoocommerce.php' );
 		$snippets[] = <<<TEXT
-add_action('woocommerce_after_checkout_form',
-        array(__CLASS__, 'trackInitiateCheckout'),
-        40);
+add_action(
+                'woocommerce_after_checkout_form',
+                array( __CLASS__, 'trackInitiateCheckout' ),
+                40
+            );
 TEXT;
 
 		$snippets[] = <<<TEXT
-add_action( 'woocommerce_add_to_cart',
-        array(__CLASS__, 'trackAddToCartEvent'),
-        40, 4);
+add_action(
+                'woocommerce_add_to_cart',
+                array( __CLASS__, 'trackAddToCartEvent' ),
+                40,
+                4
+            );
 TEXT;
 
 		$snippets[] = <<<TEXT
-add_action( 'woocommerce_thankyou',
-        array(__CLASS__, 'trackPurchaseEvent'),
-        40);
+add_action(
+                'woocommerce_thankyou',
+                array( __CLASS__, 'trackPurchaseEvent' ),
+                40
+            );
 TEXT;
 
 		$snippets[] = <<<TEXT
-add_action( 'woocommerce_payment_complete',
-        array(__CLASS__, 'trackPurchaseEvent'),
-        40);
+add_action(
+                'woocommerce_payment_complete',
+                array( __CLASS__, 'trackPurchaseEvent' ),
+                40
+            );
 TEXT;
 
 		foreach ( $snippets as $snippet ) {
@@ -230,23 +255,32 @@ TEXT;
 	 * @throws \Exception
 	 */
 	public function test_official_facebook_pixel_WPECommerce() {
-		$content    = Official_Facebook_Pixel::get_svn_file_content( 'integration/FacebookWordpressWPECommerce.php' );
+		$content    = Official_Facebook_Pixel::get_svn_file_content( 'integration/class-facebookwordpresswpecommerce.php' );
 		$snippets[] = <<<TEXT
-add_action('wpsc_add_to_cart_json_response',
-      array(__CLASS__, 'injectAddToCartEvent'), 11);
+add_action(
+            'wpsc_add_to_cart_json_response',
+            array( __CLASS__, 'injectAddToCartEvent' ),
+            11
+        );
 TEXT;
 
 		$snippets[] = <<<TEXT
-self::addPixelFireForHook(array(
-      'hook_name' => 'wpsc_before_shopping_cart_page',
-      'classname' => __CLASS__,
-      'inject_function' => 'injectInitiateCheckoutEvent'));
+self::add_pixel_fire_for_hook(
+            array(
+                'hook_name'       => 'wpsc_before_shopping_cart_page',
+                'classname'       => __CLASS__,
+                'inject_function' => 'injectInitiateCheckoutEvent',
+            )
+        );
 TEXT;
 
 		$snippets[] = <<<TEXT
 add_action(
-      'wpsc_transaction_results_shutdown',
-      array(__CLASS__, 'injectPurchaseEvent'), 11, 3);
+            'wpsc_transaction_results_shutdown',
+            array( __CLASS__, 'injectPurchaseEvent' ),
+            11,
+            3
+        );
 TEXT;
 
 		foreach ( $snippets as $snippet ) {
@@ -261,22 +295,22 @@ TEXT;
 	 * @throws \Exception
 	 */
 	public function test_official_facebook_pixel_wp_forms() {
-		$content    = Official_Facebook_Pixel::get_svn_file_content( 'integration/FacebookWordpressWPForms.php' );
+		$content    = Official_Facebook_Pixel::get_svn_file_content( 'integration/class-facebookwordpresswpforms.php' );
 		$snippets[] = <<<TEXT
 add_action(
-      'wp_footer',
-       array(__CLASS__, 'injectLeadEvent'),
-       20
-    );
+            'wp_footer',
+            array( __CLASS__, 'injectLeadEvent' ),
+            20
+        );
 TEXT;
 
 		$snippets[] = <<<TEXT
 add_action(
-      'wpforms_process_before',
-      array(__CLASS__, 'trackEvent'),
-      20,
-      2
-    );
+            'wpforms_process_before',
+            array( __CLASS__, 'trackEvent' ),
+            20,
+            2
+        );
 TEXT;
 
 		foreach ( $snippets as $snippet ) {
@@ -291,13 +325,14 @@ TEXT;
 	 * @throws \Exception
 	 */
 	public function test_official_facebook_pixel_integration_base() {
-		$content = Official_Facebook_Pixel::get_svn_file_content( 'integration/FacebookWordpressIntegrationBase.php' );
+		$content = Official_Facebook_Pixel::get_svn_file_content( 'integration/class-facebookwordpressintegrationbase.php' );
 
 		$snippet = <<<TEXT
 add_action(
-        'wp_footer',
-        \$hook_wp_footer,
-        11);
+            'wp_footer',
+            \$hook_wp_footer,
+            11
+        );
 TEXT;
 
 		$this->assertNotFalse( strpos( $content, $snippet ) );


### PR DESCRIPTION
The Cookiebot CMP by Usercentrics plugin for WordPress is vulnerable to unauthorized modification of data due to a missing capability check on the send_uninstall_survey() function in all versions up to, and including, 4.4.1. This makes it possible for authenticated attackers, with Subscriber-level access and above, to submit the uninstall survey on behalf of a website.

- Fix integration tests for Facebook Pixel addon. A breaking change was done by Facebook Pixel on version 4.1.0.