### PR TITLE
v4.6.3

### DIFF
--- a/cookiebot.php
+++ b/cookiebot.php
@@ -5,7 +5,7 @@ Plugin Name: Cookiebot by Usercentrics - Automatic Cookie Banner for GDPR/CCPA &
 Plugin URI: https://www.cookiebot.com/
 Description: Install your cookie banner in minutes. Automatically scan and block cookies to comply with the GDPR, CCPA, Google Consent Mode v2. Free plan option.
 Author: Usercentrics A/S
-Version: 4.6.2
+Version: 4.6.3
 Author URI: https://www.cookiebot.com/
 Text Domain: cookiebot
 Domain Path: /langs

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@
 * Tags: cookie banner, cookie consent, cookie notice, GDPR, privacy, cmp, consent‑management‑platform, google‑consent‑mode, compliance, gdpr‑compliance, ccpa, dma
 * Requires at least: 4.4
 * Tested up to: 6.8
-* Stable tag: 4.6.2
+* Stable tag: 4.6.3
 * Requires PHP: 5.6
 * License: GPLv2 or later
 
@@ -162,6 +162,19 @@ Usercentrics Cookiebot is fully integrated with the WP Consent API. When your vi
 
 ## Changelog ##
 **Cookiebot by Usercentrics Plugin will soon no longer support PHP 5. If your website still runs on this version we recommend upgrading so you can continue enjoying the features Cookiebot by Usercentrics offers.**
+
+### 4.6.3 ###
+Release date: January 27th 2026
+
+Cookiebot by Usercentrics version 4.6.3 is out! This release has a bugfix and an improvement
+
+####Improvements####
+
+* Enhanced script consent handling for WordPress 5.7+, including proper support for inline scripts
+
+####Bugfixes####
+
+* Fixed an issue where the consent banner could become disabled after plugin updates or hosting migrations
 
 ### 4.6.2 ###
 Release date: December 17th 2025

--- a/src/lib/Cookiebot_Activated.php
+++ b/src/lib/Cookiebot_Activated.php
@@ -86,9 +86,17 @@ class Cookiebot_Activated {
 
 	private function set_banner_enabled_by_default() {
 		$enabled = get_option( 'cookiebot-banner-enabled', 'default' );
+		$cbid    = Cookiebot_WP::get_cbid();
+		
+		// Set to enabled if it's a fresh install (default)
 		if ( $enabled === 'default' ) {
 			$enabled = '1';
 			update_option( 'cookiebot-banner-enabled', $enabled );
+		}
+		
+		// If banner is disabled but CBID is configured, it was disabled by hosting or plugin update. Re-enable it.
+		if ( $enabled === '0' && ! empty( $cbid ) ) {
+			update_option( 'cookiebot-banner-enabled', '1' );
 		}
 	}
 

--- a/src/lib/Cookiebot_Deactivated.php
+++ b/src/lib/Cookiebot_Deactivated.php
@@ -13,7 +13,6 @@ class Cookiebot_Deactivated {
 	 */
 	public function run() {
 		$this->run_addons_deactivation_hooks();
-		$this->disable_banner();
 	}
 
 	/**

--- a/src/lib/Cookiebot_WP.php
+++ b/src/lib/Cookiebot_WP.php
@@ -27,7 +27,7 @@ class Cookiebot_WP {
 		}
 	}
 
-	const COOKIEBOT_PLUGIN_VERSION  = '4.6.2';
+	const COOKIEBOT_PLUGIN_VERSION  = '4.6.3';
 	const COOKIEBOT_MIN_PHP_VERSION = '5.6.0';
 
 	/**


### PR DESCRIPTION
## **User description**
### **User description**
**Improvements**
- Enhanced script consent handling for WordPress 5.7+, including proper support for inline scripts

**Bug fixes**

- Fixed an issue where the consent banner could become disabled after plugin updates or hosting migrations


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed consent banner disabling after plugin updates or hosting migrations

- Enhanced script consent handling for WordPress 5.7+ with inline script support

- Improved script tag attribute extraction for proper consent attribute injection

- Removed banner disable logic from plugin deactivation process


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Plugin Activation"] --> B["Check Banner Status"]
  B --> C["Fresh Install?"]
  C -->|Yes| D["Enable Banner"]
  C -->|No| E["Banner Disabled + CBID Set?"]
  E -->|Yes| F["Re-enable Banner"]
  E -->|No| G["Keep Current State"]
  H["Script Tag Processing"] --> I["Extract Handle"]
  I --> J["Check Consent Required"]
  J -->|Yes| K["Add Consent Attributes"]
  J -->|No| L["Check If Ignored"]
  L -->|Yes| M["Add Ignore Attribute"]
  L -->|No| N["Return Unchanged"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cookiebot.php</strong><dd><code>Version bump to 4.6.3</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cookiebot.php

- Updated plugin version from 4.6.2 to 4.6.3


</details>


  </td>
  <td><a href="https://github.com/CybotAS/CookiebotWP/pull/361/files#diff-492eac8e072f4b4575ce990af4f2723148e1471e241a90d6d4f753b58f5c5432">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Cookiebot_WP.php</strong><dd><code>Update version constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/Cookiebot_WP.php

- Updated plugin version constant from 4.6.2 to 4.6.3


</details>


  </td>
  <td><a href="https://github.com/CybotAS/CookiebotWP/pull/361/files#diff-0b0113ff0407c82f4f7482649284b40793990434d9a4787943a226f4f4d67df5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cookiebot_Activated.php</strong><dd><code>Fix banner disable on updates and migrations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/Cookiebot_Activated.php

<ul><li>Added logic to re-enable banner if disabled but CBID is configured<br> <li> Detects when banner was disabled by hosting or plugin update<br> <li> Preserves fresh install behavior while recovering from unintended <br>disables</ul>


</details>


  </td>
  <td><a href="https://github.com/CybotAS/CookiebotWP/pull/361/files#diff-ecab73d33ad46b58cebd3f6b599632e716cb1ade92881f32c413964000d1c39b">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Cookiebot_Deactivated.php</strong><dd><code>Remove banner disable on deactivation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/Cookiebot_Deactivated.php

<ul><li>Removed call to <code>disable_banner()</code> from deactivation process<br> <li> Prevents unintended banner disabling when plugin is deactivated</ul>


</details>


  </td>
  <td><a href="https://github.com/CybotAS/CookiebotWP/pull/361/files#diff-f0d9e60b0fbcf9efda436d55b6f9558e5ae8d079ce579907bd2a9a0ab2f65575">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Script_Loader_Tag.php</strong><dd><code>Enhance consent attribute handling for inline scripts</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/script_loader_tag/Script_Loader_Tag.php

<ul><li>Enhanced <code>cookiebot_add_consent_attribute_to_script_tag()</code> to handle <br>consent-required scripts via <code>add_tag</code> registration<br> <li> Added <code>extract_handle_from_attributes()</code> method to extract script <br>handles from tag attributes<br> <li> Improved <code>cookiebot_add_consent_attribute_to_inline_script_tag()</code> to <br>support inline scripts with consent requirements<br> <li> Added proper handling for both consent-required and ignored inline <br>scripts<br> <li> Updated documentation to clarify WordPress 5.7+ support for both <br>external and inline scripts</ul>


</details>


  </td>
  <td><a href="https://github.com/CybotAS/CookiebotWP/pull/361/files#diff-669f65122c95acbce1759f6c6be293f94db1877bdf55d8e69fc2aebcf7d52369">+53/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>readme.txt</strong><dd><code>Update readme with v4.6.3 release notes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

readme.txt

<ul><li>Updated stable tag from 4.6.2 to 4.6.3<br> <li> Added changelog entry for version 4.6.3 with improvements and bugfixes<br> <li> Documented enhanced script consent handling and banner disable fix</ul>


</details>


  </td>
  <td><a href="https://github.com/CybotAS/CookiebotWP/pull/361/files#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6">+14/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___


___

## **CodeAnt-AI Description**
**Restore banner when CBID present and add consent handling for WordPress 5.7+**

### What Changed
- If the banner was previously disabled but a Cookiebot ID (CBID) is configured, the banner is now automatically re-enabled so the cookie banner appears after updates or migrations.
- Plugin deactivation no longer disables the cookie banner, preventing accidental banner removal when the plugin is turned off.
- Script consent attributes are now applied for WordPress 5.7+: both external scripts and their inline fragments receive proper consent attributes (type set to text/plain and data-cookieconsent with the required categories), and admin/ignored scripts get a data-cookieconsent="ignore" attribute.
- Version, stable tag, and changelog updated to 4.6.3.

### Impact
`✅ Banner restored after plugin updates or hosting migrations`
`✅ Correct consent enforcement for inline scripts on WP 5.7+`
`✅ Banner not removed on plugin deactivation`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
