### PR TITLE
Fix: formatting hotfix

### DIFF
--- a/src/lib/Cookiebot_Activated.php
+++ b/src/lib/Cookiebot_Activated.php
@@ -87,13 +87,13 @@ class Cookiebot_Activated {
 	private function set_banner_enabled_by_default() {
 		$enabled = get_option( 'cookiebot-banner-enabled', 'default' );
 		$cbid    = Cookiebot_WP::get_cbid();
-		
+
 		// Set to enabled if it's a fresh install (default)
 		if ( $enabled === 'default' ) {
 			$enabled = '1';
 			update_option( 'cookiebot-banner-enabled', $enabled );
 		}
-		
+
 		// If banner is disabled but CBID is configured, it was disabled by hosting or plugin update. Re-enable it.
 		if ( $enabled === '0' && ! empty( $cbid ) ) {
 			update_option( 'cookiebot-banner-enabled', '1' );

--- a/src/lib/script_loader_tag/Script_Loader_Tag.php
+++ b/src/lib/script_loader_tag/Script_Loader_Tag.php
@@ -111,7 +111,7 @@ class Script_Loader_Tag implements Script_Loader_Tag_Interface {
 	public function cookiebot_add_consent_attribute_to_script_tag( $attributes ) {
 		// First, check if this script requires consent (registered via add_tag)
 		$handle = $this->extract_handle_from_attributes( $attributes );
-		
+
 		if ( $handle && array_key_exists( $handle, $this->tags ) && ! empty( $this->tags[ $handle ] ) ) {
 			$attributes['type']               = 'text/plain';
 			$attributes['data-cookieconsent'] = implode( ',', $this->tags[ $handle ] );
@@ -141,7 +141,7 @@ class Script_Loader_Tag implements Script_Loader_Tag_Interface {
 
 		// Check if inline script belongs to a consent-required parent script
 		$base_handle = $this->extract_base_id_from_inline_id( $attributes['id'] );
-		
+
 		if ( $base_handle && array_key_exists( $base_handle, $this->tags ) && ! empty( $this->tags[ $base_handle ] ) ) {
 			$attributes['type']               = 'text/plain';
 			$attributes['data-cookieconsent'] = implode( ',', $this->tags[ $base_handle ] );


### PR DESCRIPTION
## **User description**
### **PR Type**
Bug fix


___

### **Description**
- Remove trailing whitespace from multiple files

- Clean up formatting inconsistencies in PHP code


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PHP Files with<br/>Trailing Whitespace"] -- "Remove whitespace" --> B["Clean Formatted<br/>Code"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cookiebot_Activated.php</strong><dd><code>Remove trailing whitespace in Cookiebot_Activated</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/Cookiebot_Activated.php

<ul><li>Remove trailing whitespace on lines 90 and 95<br> <li> Clean up empty lines in <code>set_banner_enabled_by_default()</code> method</ul>


</details>


  </td>
  <td><a href="https://github.com/CybotAS/CookiebotWP/pull/362/files#diff-ecab73d33ad46b58cebd3f6b599632e716cb1ade92881f32c413964000d1c39b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Script_Loader_Tag.php</strong><dd><code>Remove trailing whitespace in Script_Loader_Tag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/script_loader_tag/Script_Loader_Tag.php

<ul><li>Remove trailing whitespace on lines 114 and 144<br> <li> Clean up empty lines in consent attribute methods</ul>


</details>


  </td>
  <td><a href="https://github.com/CybotAS/CookiebotWP/pull/362/files#diff-669f65122c95acbce1759f6c6be293f94db1877bdf55d8e69fc2aebcf7d52369">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___


___

## **CodeAnt-AI Description**
Remove trailing whitespace and clean up PHP formatting

### What Changed
- Removed trailing whitespace and stray empty lines in PHP files that caused formatting inconsistencies (script loader and Cookiebot activation logic)
- Consolidated blank lines inside functions to produce consistent file formatting
- No changes to runtime behavior or feature logic

### Impact
`✅ Fewer lint/format warnings`
`✅ Cleaner diffs and PR reviews`
`✅ No functional change`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
