### PR TITLE
V4.6.4

### DIFF
--- a/assets/js/backend/network-settings-page.js
+++ b/assets/js/backend/network-settings-page.js
@@ -79,9 +79,9 @@ function show_ruleset_selector() {
         return;
     }
 
-    // Validate that the field has exactly 14 or 36 characters
+    // Validate that the field has exactly 9, 14 or 36 characters
     const fieldLength = cbidField.val().length;
-    if(fieldLength !== 14 && fieldLength !== 36){
+    if(fieldLength !== 9 && fieldLength !== 14 && fieldLength !== 36){
         cbidCheck.removeClass('check-pass');
         cbidRulesetSelector.addClass('hidden');
         cbidSubmit.addClass('disabled');

--- a/assets/js/backend/settings-page.js
+++ b/assets/js/backend/settings-page.js
@@ -64,9 +64,9 @@ function show_ruleset_selector() {
         return;
     }
 
-    // Validate that the field has exactly 14 or 36 characters
+    // Validate that the field has exactly 9, 14 or 36 characters
     const fieldLength = cbidField.val().length;
-    if(fieldLength !== 14 && fieldLength !== 36){
+    if(fieldLength !== 9 && fieldLength !== 14 && fieldLength !== 36){
         cbidCheck.removeClass('check-pass');
         cbidRulesetSelector.addClass('hidden');
         cbidError.removeClass('hidden');
@@ -176,7 +176,7 @@ function closeSubmitMsg() {
 }
 
 function submitEnable() {
-    const initialValues = jQuery('input[name!=_wp_http_referer]','form').serialize();
+    const initialValues = jQuery(':input[name!=_wp_http_referer]','form').serialize();
     const events = {
         change: 'input:not([type=text]), select',
         input: 'input[type="text"], textarea'
@@ -192,7 +192,7 @@ function submitEnable() {
 
 function checkValues(initialValues){
     let submitBtn = jQuery('.cb-settings__header p.submit #submit');
-    let newValues = jQuery('input[name!=_wp_http_referer]','form').serialize();
+    let newValues = jQuery(':input[name!=_wp_http_referer]','form').serialize();
     if(newValues !== initialValues) {
         submitBtn.addClass('enabled');
     }else{
@@ -349,7 +349,7 @@ function onVendorSelection() {
 }
 
 function removeRestriction(){
-    const initialValues = jQuery('input[name!=_wp_http_referer]','form').serialize();
+    const initialValues = jQuery(':input[name!=_wp_http_referer]','form').serialize();
     let submitBtn = jQuery('.cb-settings__header p.submit #submit');
     jQuery(document).on('click','.cb-settings__vendor__restrictions .remove__restriction', function(){
         const restriction = jQuery(this).closest( '.cb-settings__vendor__restrictions' );
@@ -368,7 +368,7 @@ function removeRestriction(){
         }else{
             restriction.remove();
         }
-        let newValues = jQuery('input[name!=_wp_http_referer]','form').serialize();
+        let newValues = jQuery(':input[name!=_wp_http_referer]','form').serialize();
         if(newValues !== initialValues) {
             submitBtn.addClass('enabled');
         }else{

--- a/cookiebot.php
+++ b/cookiebot.php
@@ -5,7 +5,7 @@ Plugin Name: Cookiebot by Usercentrics - Automatic Cookie Banner for GDPR/CCPA &
 Plugin URI: https://www.cookiebot.com/
 Description: Install your cookie banner in minutes. Automatically scan and block cookies to comply with the GDPR, CCPA, Google Consent Mode v2. Free plan option.
 Author: Usercentrics A/S
-Version: 4.6.3
+Version: 4.6.4
 Author URI: https://www.cookiebot.com/
 Text Domain: cookiebot
 Domain Path: /langs

--- a/readme.txt
+++ b/readme.txt
@@ -164,7 +164,7 @@ Usercentrics Cookiebot is fully integrated with the WP Consent API. When your vi
 **Cookiebot by Usercentrics Plugin will soon no longer support PHP 5. If your website still runs on this version we recommend upgrading so you can continue enjoying the features Cookiebot by Usercentrics offers.**
 
 ### 4.6.4 ###
-Release date: February 11th 2026
+Release date: February 12th 2026
 
 Cookiebot by Usercentrics version 4.6.4 is out! This release has an improvement and a bugfix
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@
 * Tags: cookie banner, cookie consent, cookie notice, GDPR, privacy, cmp, consent‑management‑platform, google‑consent‑mode, compliance, gdpr‑compliance, ccpa, dma
 * Requires at least: 4.4
 * Tested up to: 6.8
-* Stable tag: 4.6.3
+* Stable tag: 4.6.4
 * Requires PHP: 5.6
 * License: GPLv2 or later
 
@@ -162,6 +162,19 @@ Usercentrics Cookiebot is fully integrated with the WP Consent API. When your vi
 
 ## Changelog ##
 **Cookiebot by Usercentrics Plugin will soon no longer support PHP 5. If your website still runs on this version we recommend upgrading so you can continue enjoying the features Cookiebot by Usercentrics offers.**
+
+### 4.6.4 ###
+Release date: February 11th 2026
+
+Cookiebot by Usercentrics version 4.6.4 is out! This release has an improvement and a bugfix
+
+####Improvements####
+
+* Added support for 9-character Settings IDs in the account connection field
+
+####Bugfixes####
+
+* Fixed form change detection on the settings page to track all input types
 
 ### 4.6.3 ###
 Release date: January 27th 2026

--- a/src/lib/Cookiebot_WP.php
+++ b/src/lib/Cookiebot_WP.php
@@ -27,7 +27,7 @@ class Cookiebot_WP {
 		}
 	}
 
-	const COOKIEBOT_PLUGIN_VERSION  = '4.6.3';
+	const COOKIEBOT_PLUGIN_VERSION  = '4.6.4';
 	const COOKIEBOT_MIN_PHP_VERSION = '5.6.0';
 
 	/**

--- a/src/view/admin/cb_frame/settings/general-page.php
+++ b/src/view/admin/cb_frame/settings/general-page.php
@@ -81,7 +81,7 @@ if ( ! empty( $network_cbid ) ) {
 			<?php if ( ! empty( $network_cbid ) ) : ?>
 				<div class="cookiebot-cbid-error-container">
 					<div class="cookiebot-cbid-error hidden" style="color: #d63638; margin-top: 8px; font-size: 14px;">
-						<?php esc_html_e( 'Invalid ID length. Please enter a Settings ID (14 characters) or Domain Group ID (36 characters).', 'cookiebot' ); ?>
+						<?php esc_html_e( 'Invalid ID length. Please enter a Settings ID (9 or 14 characters) or Domain Group ID (36 characters).', 'cookiebot' ); ?>
 					</div>
 				</div>
 				<div id="cb-network-id-override">

--- a/src/view/admin/common/network-settings-page.php
+++ b/src/view/admin/common/network-settings-page.php
@@ -61,7 +61,7 @@ $header->display();
 									</h3>
 									<div class="cookiebot-cbid-container">
 										<div class="cookiebot-cbid-input">
-											<input placeholder="<14 chars> or <36 chars>"
+											<input placeholder="9, 14 or 36 characters"
 													type="text" id="cookiebot-cbid" class="initial-cbid-setup"
 													name="cookiebot-cbid"
 													value="<?php echo esc_attr( get_site_option( 'cookiebot-cbid', '' ) ); ?>"/>
@@ -69,7 +69,7 @@ $header->display();
 										</div>
 										<?php submit_button( esc_html__( 'Connect account', 'cookiebot' ), 'disabled' ); ?>
 										<div class="cookiebot-cbid-error hidden" style="color: #d63638; margin-top: 8px; font-size: 14px;">
-											<?php esc_html_e( 'Invalid ID length. Please enter a Settings ID (14 characters) or Domain Group ID (36 characters).', 'cookiebot' ); ?>
+											<?php esc_html_e( 'Invalid ID length. Please enter a Settings ID (9 or 14 characters) or Domain Group ID (36 characters).', 'cookiebot' ); ?>
 										</div>
 									</div>
 								</div>

--- a/src/view/admin/common/settings-page.php
+++ b/src/view/admin/common/settings-page.php
@@ -65,7 +65,7 @@ $header->display();
 									</h3>
 									<div class="cookiebot-cbid-container">
 										<div class="cookiebot-cbid-input">
-											<input placeholder="<14 chars> or <36 chars>"
+											<input placeholder="9, 14 or 36 characters"
 												type="text" id="cookiebot-cbid" class="initial-cbid-setup"
 												name="cookiebot-cbid"
 												value="<?php echo esc_attr( $cbid ); ?>"/>
@@ -73,7 +73,7 @@ $header->display();
 										</div>
 										<?php submit_button( esc_html__( 'Connect account', 'cookiebot' ), 'disabled' ); ?>
 										<div class="cookiebot-cbid-error hidden" style="color: #d63638; margin-top: 8px; font-size: 14px;">
-											<?php esc_html_e( 'Invalid ID length. Please enter a Settings ID (14 characters) or Domain Group ID (36 characters).', 'cookiebot' ); ?>
+											<?php esc_html_e( 'Invalid ID length. Please enter a Settings ID (9 or 14 characters) or Domain Group ID (36 characters).', 'cookiebot' ); ?>
 										</div>
 									</div>
 								</div>

--- a/src/view/admin/uc_frame/settings/general-page.php
+++ b/src/view/admin/uc_frame/settings/general-page.php
@@ -100,7 +100,7 @@ if ( ! empty( $network_cbid ) ) {
 			<?php if ( ! empty( $network_cbid ) ) : ?>
 				<div class="cookiebot-cbid-error-container">
 					<div class="cookiebot-cbid-error hidden" style="color: #d63638; margin-top: 8px; font-size: 14px;">
-						<?php esc_html_e( 'Invalid ID length. Please enter a Settings ID (14 characters) or Domain Group ID (36 characters).', 'cookiebot' ); ?>
+						<?php esc_html_e( 'Invalid ID length. Please enter a Settings ID (9 or 14 characters) or Domain Group ID (36 characters).', 'cookiebot' ); ?>
 					</div>
 				</div>
 				<div id="cb-network-id-override">

--- a/src/widgets/Dashboard_Widget_Cookiebot_Status.php
+++ b/src/widgets/Dashboard_Widget_Cookiebot_Status.php
@@ -43,7 +43,7 @@ class Dashboard_Widget_Cookiebot_Status {
 			echo esc_html__( 'Update your Cookiebot ID', 'cookiebot' );
 			echo '</a></p>';
 		} else {
-			echo '<p>' . esc_html_e( 'Your Cookiebot is working!', 'cookiebot' ) . '</p>';
+			echo '<p>' . esc_html__( 'Your Cookiebot is working!', 'cookiebot' ) . '</p>';
 		}
 	}
 }

--- a/src/widgets/Dashboard_Widget_Cookiebot_Status.php
+++ b/src/widgets/Dashboard_Widget_Cookiebot_Status.php
@@ -43,7 +43,7 @@ class Dashboard_Widget_Cookiebot_Status {
 			echo esc_html__( 'Update your Cookiebot ID', 'cookiebot' );
 			echo '</a></p>';
 		} else {
-			echo '<p>' . esc_html__( 'Your Cookiebot is working!', 'cookiebot' ) . '</p>';
+			echo '<p>' . esc_html_e( 'Your Cookiebot is working!', 'cookiebot' ) . '</p>';
 		}
 	}
 }


### PR DESCRIPTION
## **User description**
**Improvements**

* Added support for 9-character Settings IDs in the account connection field

**Bugfixes**

* Fixed form change detection on the settings page to track all input types


___

## **CodeAnt-AI Description**
Add 9-character Settings ID support and fix settings form change detection

### What Changed
- Account connection fields and messages now accept Settings IDs of 9, 14, or 36 characters (placeholders, validation, and error text updated) so 9-character IDs are accepted without error.
- Client-side validation on network and settings pages updated to treat 9-character IDs as valid, showing the ruleset selector and enabling connect when appropriate.
- Settings page form-change detection now monitors all input elements (not only text inputs) so the Save/Connect button correctly enables when any form field changes.
- Package metadata bumped to version 4.6.4 and changelog/readme updated to reflect these changes.

### Impact
`✅ Can connect accounts using 9-character Settings ID`
`✅ Fewer missed form change detections on the settings page`
`✅ Clearer ID validation errors preventing false negatives`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
