### PR TITLE
Fix: prepare v4.6.6

### DIFF
--- a/cookiebot.php
+++ b/cookiebot.php
@@ -5,7 +5,7 @@ Plugin Name: Cookiebot by Usercentrics - Automatic Cookie Banner for GDPR/CCPA &
 Plugin URI: https://www.cookiebot.com/
 Description: Install your cookie banner in minutes. Automatically scan and block cookies to comply with the GDPR, CCPA, Google Consent Mode v2. Free plan option.
 Author: Usercentrics A/S
-Version: 4.6.5
+Version: 4.6.6
 Author URI: https://www.cookiebot.com/
 Text Domain: cookiebot
 Domain Path: /langs

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
-﻿# Cookiebot by Usercentrics - Automatic Cookie Banner for GDPR/CCPA & Google Consent Mode #
+# Cookiebot by Usercentrics - Automatic Cookie Banner for GDPR/CCPA & Google Consent Mode #
 * Contributors: cookiebot,phpgeekdk,aytac
 * Tags: cookie banner, cookie consent, cookie notice, GDPR, privacy, cmp, consent‑management‑platform, google‑consent‑mode, compliance, gdpr‑compliance, ccpa, dma
 * Requires at least: 4.4
 * Tested up to: 6.8
-* Stable tag: 4.6.5
+* Stable tag: 4.6.6
 * Requires PHP: 5.6
 * License: GPLv2 or later
 
@@ -163,6 +163,15 @@ Usercentrics Cookiebot is fully integrated with the WP Consent API. When your vi
 ## Changelog ##
 **Cookiebot by Usercentrics Plugin will soon no longer support PHP 5. If your website still runs on this version we recommend upgrading so you can continue enjoying the features Cookiebot by Usercentrics offers.**
 
+
+### 4.6.6 ###
+Release date: March 12th 2026
+
+Cookiebot by Usercentrics version 4.6.6 is out! This release includes an improvement.
+
+####Improvements####
+
+* Improved tracking for PPG redirect — the redirect URL with tracking parameters is now available in all PPG page states, not only when the plugin is inactive
 
 ### 4.6.5 ###
 Release date: March 3rd 2026

--- a/src/lib/Cookiebot_WP.php
+++ b/src/lib/Cookiebot_WP.php
@@ -28,7 +28,7 @@ class Cookiebot_WP {
 		}
 	}
 
-	const COOKIEBOT_PLUGIN_VERSION  = '4.6.5';
+	const COOKIEBOT_PLUGIN_VERSION  = '4.6.6';
 	const COOKIEBOT_MIN_PHP_VERSION = '5.6.0';
 
 	/**

--- a/src/settings/pages/PPG_Page.php
+++ b/src/settings/pages/PPG_Page.php
@@ -50,6 +50,9 @@ class PPG_Page implements Settings_Page_Interface {
 			wp_send_json_error( array( 'message' => $result->get_error_message() ), 500 );
 		}
 
+		// Prevent PPG's own activation redirect from stripping our ppg_ref query param.
+		delete_transient( 'ppguc_activation_redirect' );
+
 		wp_send_json_success();
 	}
 
@@ -100,6 +103,14 @@ class PPG_Page implements Settings_Page_Interface {
 		$is_installed = self::is_plugin_installed();
 		$is_active    = self::is_plugin_active();
 
+		$ppg_redirect_url = add_query_arg(
+			array(
+				'page'    => 'privacy-policy-usercentrics',
+				'ppg_ref' => 'content-distribution',
+			),
+			admin_url( 'admin.php' )
+		);
+
 		if ( ! $is_active ) {
 			wp_enqueue_script(
 				'cookiebot-ppg-page-js',
@@ -107,14 +118,6 @@ class PPG_Page implements Settings_Page_Interface {
 				array(),
 				Cookiebot_WP::COOKIEBOT_PLUGIN_VERSION,
 				true
-			);
-
-			$ppg_redirect_url = add_query_arg(
-				array(
-					'page'    => 'privacy-policy-usercentrics',
-					'ppg_ref' => 'content-distribution',
-				),
-				admin_url( 'admin.php' )
 			);
 
 			wp_localize_script(
@@ -135,9 +138,10 @@ class PPG_Page implements Settings_Page_Interface {
 		}
 
 		$args = array(
-			'hero_image'   => asset_url( 'img/ppg-hero.png' ),
-			'is_installed' => $is_installed,
-			'is_active'    => $is_active,
+			'hero_image'        => asset_url( 'img/ppg-hero.png' ),
+			'is_installed'      => $is_installed,
+			'is_active'         => $is_active,
+			'ppg_redirect_url'  => $ppg_redirect_url,
 		);
 
 		include_view( 'admin/common/ppg-page.php', $args );

--- a/src/settings/pages/PPG_Page.php
+++ b/src/settings/pages/PPG_Page.php
@@ -138,10 +138,10 @@ class PPG_Page implements Settings_Page_Interface {
 		}
 
 		$args = array(
-			'hero_image'        => asset_url( 'img/ppg-hero.png' ),
-			'is_installed'      => $is_installed,
-			'is_active'         => $is_active,
-			'ppg_redirect_url'  => $ppg_redirect_url,
+			'hero_image'       => asset_url( 'img/ppg-hero.png' ),
+			'is_installed'     => $is_installed,
+			'is_active'        => $is_active,
+			'ppg_redirect_url' => $ppg_redirect_url,
 		);
 
 		include_view( 'admin/common/ppg-page.php', $args );


### PR DESCRIPTION
## **User description**
**Improvements**

- Improved tracking for PPG redirect — the redirect URL with tracking parameters is now available in all PPG page states, not only when the plugin is inactive


___

## **CodeAnt-AI Description**
Preserve PPG redirect tracking across page states and during plugin activation

### What Changed
- The PPG redirect URL that includes the ppg_ref tracking parameter is now generated and passed to the PPG page view regardless of whether the linked plugin is active or not, so the tracking URL is always available in the UI.
- During AJAX activation of the PPG plugin, the code removes the plugin's activation redirect transient to prevent the activation redirect from stripping the ppg_ref query parameter.
- Plugin version constants and the readme were updated to 4.6.6 and include a short release note describing this change.

### Impact
`✅ Clearer PPG redirect tracking in all PPG page states`
`✅ Fewer lost ppg_ref tracking parameters when activating the PPG plugin`
`✅ Accurate plugin version and release notes for users`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
